### PR TITLE
Parámetro 'version' en algunas funciones relacionadas con google drive

### DIFF
--- a/R/metadata.R
+++ b/R/metadata.R
@@ -6,17 +6,23 @@
 #' @return dataframe con la metadata
 #' @export
 #'
+source("R/subtopicos_dir.R")
+source("R/utils.R")
 
 
 metadata <- function(subtopico = NULL,
-                     fuentes = FALSE) {
+                     fuentes = FALSE,
+                     version = NULL) {
+  
+  if(version == 'v2'){skip = NULL}
+  else{skip = 6}
 
   stopifnot("'subtopico' debe ser string con codigo de 6 letras de subtopico" = is.character(subtopico))
 
   subtopico <- toupper(subtopico)
 
   # Lista los archivos o carpetas dentro de la carpeta de subtemas utilizando su ID
-  paths_subtopicos <- subtopicos_dir()$tree
+  paths_subtopicos <- subtopicos_dir(version)$tree
 
   stopifnot("'subtopico' no hallado en el drive" = any(grepl(subtopico, paths_subtopicos$name)))
 
@@ -37,7 +43,7 @@ metadata <- function(subtopico = NULL,
 
   # Para cada archivo de metadatos, lee su contenido saltando las primeras 6 filas y asumiendo que las columnas son tipo texto
   metadata <- purrr::map2(metadata_files$id, metadata_files$name, function(x, y) {
-    df <- googlesheets4::read_sheet(x, skip = 6, col_types = "c")
+    df <- googlesheets4::read_sheet(x, skip = skip, col_types = "c")
     df %>%
       dplyr::mutate(subtopico_nombre = gsub("ArgenData - ", "", y))
   })
@@ -67,3 +73,4 @@ metadata <- function(subtopico = NULL,
   return(metadata)
   
 }
+

--- a/R/subtopicos_dir.R
+++ b/R/subtopicos_dir.R
@@ -5,14 +5,13 @@
 
 subtopicos_dir <- function(version=NULL) {
   
-  ersion = NULL
+  
   search_string = 'subtopicos_dir'
   temp_out <- tempfile(pattern = "subtopicos_dir_argdt", fileext = ".rds")
   folder_name <- "SUBTOPICOS"
   
   if (version == 'v2'){
     
-    version = 'v2'
     search_string = 'subtopicos_dir.*v2'
     temp_out <- tempfile(pattern = "subtopicos_dir_argdt_v2", fileext = ".rds")
     folder_name <- "TOPICOS"

--- a/R/subtopicos_dir.R
+++ b/R/subtopicos_dir.R
@@ -3,11 +3,25 @@
 #' @keywords internal
 #' @export
 
-subtopicos_dir <- function() {
+subtopicos_dir <- function(version=NULL) {
+  
+  ersion = NULL
+  search_string = 'subtopicos_dir'
+  temp_out <- tempfile(pattern = "subtopicos_dir_argdt", fileext = ".rds")
+  folder_name <- "SUBTOPICOS"
+  
+  if (version == 'v2'){
+    
+    version = 'v2'
+    search_string = 'subtopicos_dir.*v2'
+    temp_out <- tempfile(pattern = "subtopicos_dir_argdt_v2", fileext = ".rds")
+    folder_name <- "TOPICOS"
+  
+    }
+  
+  argendata_root_dir <- argendata_root_dir(version)
 
-  argendata_root_dir <- argendata_root_dir()
-
-  filetemp <- list.files(tempdir(), full.names = T)[grepl("subtopicos_dir", list.files(tempdir()))]
+  filetemp <- list.files(tempdir(), full.names = T)[grepl(search_string, list.files(tempdir()))]
 
   if (length(filetemp) == 1) {
 
@@ -16,10 +30,10 @@ subtopicos_dir <- function() {
   } else {
 
     subtopicos_dir <- list()
-    subtopicos_dir$id <- argendata_root_dir$id[argendata_root_dir$name == "SUBTOPICOS"]
+    subtopicos_dir$id <- argendata_root_dir$id[argendata_root_dir$name == folder_name]
     subtopicos_dir$tree <- googledrive::drive_ls(googledrive::as_id(subtopicos_dir$id))
 
-    readr::write_rds(subtopicos_dir, tempfile(pattern = "subtopicos_dir_argdt", fileext = ".rds"))
+    readr::write_rds(subtopicos_dir, temp_out)
 
     subtopicos_dir
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -43,21 +43,38 @@ IP_FUENTES <- function() {
 #' @keywords internal
 #'
 
-argendata_root_dir <- function() {
+argendata_root_dir <- function(version=NULL){
+  
+  if (version == 'v2'){
+  
+  root_dir_id <- Sys.getenv("ARGENDATA_DRIVE_V2")    
+  stopifnot("ARGENDATA_DRIVE_V2 no esta definido en .Renviron o esta mal escrito" = nchar(root_dir_id) == 19)
 
-  stopifnot("ARGENDATA_DRIVE no esta definido en .Renviron o esta mal escrito" = nchar(Sys.getenv("ARGENDATA_DRIVE")) == 33)
-
-  filetemp <- list.files(tempdir(), full.names = T)[grepl("argendata_root_dir", list.files(tempdir()))]
-
+  filetemp <- list.files(tempdir(), full.names = T)[grepl("argendata_root_dir.*v2", list.files(tempdir()))]
+  
+  out_temp <- tempfile("argendata_root_dir_argdt_v2")
+  
+  }else{
+    
+    root_dir_id <- Sys.getenv("ARGENDATA_DRIVE") 
+    
+    stopifnot("ARGENDATA_DRIVE no esta definido en .Renviron o esta mal escrito" = nchar(root_dir_id) == 33)
+    
+    filetemp <- list.files(tempdir(), full.names = T)[grepl("argendata_root_dir", list.files(tempdir()))]
+    
+    out_temp <- tempfile("argendata_root_dir_argdt")
+    
+  }
+  
   if (length(filetemp) == 1) {
 
     readr::read_rds(filetemp)
 
   } else {
 
-    argendata_root_dir <- googledrive::drive_ls(googledrive::as_id(Sys.getenv("ARGENDATA_DRIVE")))
+    argendata_root_dir <- googledrive::drive_ls(googledrive::as_id(root_dir_id))
 
-    readr::write_rds(argendata_root_dir, file = tempfile("argendata_root_dir_argdt"))
+    readr::write_rds(argendata_root_dir, file = out_temp)
 
     argendata_root_dir
 


### PR DESCRIPTION
Se agrega parámetro 'version' en algunas funciones de búsqueda de archivos en el directorio de argendata. 

El sistema de archivos nuevo obliga a modificar código, por las siguientes razones: 

1. Existe un nuevo sistema de archivos que convive con el anterior. 
2. En el nuevo filesystem de googledrive la carpeta que almacena cada uno de los tópicos tiene un nombre distinto al nombre que lleva en la v1. 
3. El id root de google drive ha sido modificado

Para ello se propone agregar un parámetro 'version' que permita elegir uno u otro sistema de archivos, hasta que el sistema de archivos anterior quede en desuso.  Las funciones que en este PR se han modificado son: `argendata_root_dir`, `subtopicos_dir` y `metadata`. 